### PR TITLE
[HW-8] Fix linters warnings

### DIFF
--- a/DemoApp/ParenthesesValidator/ContentView.swift
+++ b/DemoApp/ParenthesesValidator/ContentView.swift
@@ -24,13 +24,11 @@ struct ContentView: View {
             }, label: {
                 Text(buttonTitle(for: viewModel.inputTextValidityState))
             })
-            // swiftlint:disable no_magic_numbers
             .padding(5)
             .background(
                 RoundedRectangle(cornerRadius: 10.0)
                     .fill(borderColor(for: viewModel.inputTextValidityState))
             )
-            // swiftlint:enable no_magic_numbers
             .disabled(viewModel.inputText.isEmpty)
             .onReceive(viewModel.$inputText, perform: { _ in
                 viewModel.textWasChanged()

--- a/DemoApp/ParenthesesValidator/ContentView.swift
+++ b/DemoApp/ParenthesesValidator/ContentView.swift
@@ -24,11 +24,13 @@ struct ContentView: View {
             }, label: {
                 Text(buttonTitle(for: viewModel.inputTextValidityState))
             })
+            // swiftlint:disable no_magic_numbers
             .padding(5)
             .background(
                 RoundedRectangle(cornerRadius: 10.0)
                     .fill(borderColor(for: viewModel.inputTextValidityState))
             )
+            // swiftlint:enable no_magic_numbers
             .disabled(viewModel.inputText.isEmpty)
             .onReceive(viewModel.$inputText, perform: { _ in
                 viewModel.textWasChanged()

--- a/LifoContainers/LifoContainers/Stacks/StackStatistics.swift
+++ b/LifoContainers/LifoContainers/Stacks/StackStatistics.swift
@@ -12,7 +12,8 @@
 public struct StackStatistics<Element: Comparable>: LIFO {
     /// The underlying storage of the elements of the stack.
     private var elements: [Element]
-    /// Keeps minimum elements in the stack. The current minimum is the element at the top of the stack.
+    /// Keeps minimum elements in the stack.
+    /// The current minimum is the element at the top of the stack.
     private var minimumElements = Stack<Element>()
 
     /// Creates a new instance of the `StackStatistics` with initial elements.


### PR DESCRIPTION
The pull request **MUST** be merged **AFTER**:
- #36 

## List of changes

- all Swiftformat and Swiftlint warnings have been fixed
